### PR TITLE
Harden SECRET_KEY setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,9 +183,11 @@ In addition to return calculations, the backtester computes several risk-adjuste
 
 4. **Environment Variables:**
 
-   Set up necessary environment variables. For example, set your FRED API key:
-   
+   Set up necessary environment variables. At a minimum you must define a
+   `SECRET_KEY` for Flask sessions. You can also set your FRED API key:
+
    ```bash
+   export SECRET_KEY="change_me"
    export FRED_API_KEY="your_fred_api_key_here"
    ```
 
@@ -193,7 +195,8 @@ In addition to return calculations, the backtester computes several risk-adjuste
 
 1. **Run the Application:**
 
-   With your virtual environment activated, start the Flask server:
+   Ensure the `SECRET_KEY` environment variable is defined, then start the Flask
+   server with your virtual environment activated:
    
    ```bash
    python app.py

--- a/config.py
+++ b/config.py
@@ -7,7 +7,9 @@ basedir = os.path.abspath(os.path.dirname(__file__))
 
 class Config:
     # Basic Flask settings
-    SECRET_KEY = os.environ.get('SECRET_KEY') or 'you-will-never-guess'
+    # SECRET_KEY must be provided through the environment for production and
+    # development configurations.
+    SECRET_KEY = os.environ.get('SECRET_KEY')
     DEBUG = False
     TESTING = False
 
@@ -29,6 +31,7 @@ class DevelopmentConfig(Config):
 
 class TestingConfig(Config):
     TESTING = True
+    SECRET_KEY = os.environ.get('SECRET_KEY') or 'test-secret-key'
     SQLALCHEMY_DATABASE_URI = 'sqlite:///:memory:'
 
 class ProductionConfig(Config):


### PR DESCRIPTION
## Summary
- remove default SECRET_KEY from base config
- provide test-only fallback in TestingConfig
- document required SECRET_KEY environment variable

## Testing
- `pip install -q -r requirments.txt`
- `pip install python-dotenv -q`
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685433323bf483248bf313b6a6a44805