### PR TITLE
Fix beta calculation

### DIFF
--- a/app.py
+++ b/app.py
@@ -192,10 +192,14 @@ def backtest():
     strategy_drawdown = (strategy_cum / strategy_cum.cummax() - 1).min() # max drawdown
 
     # Beta, Jensen's Alpha, Treynor Ratio (using naive returns as benchmark)
-    cov_matrix = np.cov(strategy_daily_returns, naive_returns) # covariance matrix
-    strategy_beta = cov_matrix[0, 1] / (cov_matrix[1, 1] if cov_matrix[1, 1] != 0 else 1) # beta
-    jensens_alpha = (strategy_avg_excess - strategy_beta * naive_avg_excess) # Jensen's alpha
-    strategy_treynor = strategy_avg_excess / (strategy_beta if strategy_beta != 0 else 1) # Treynor ratio
+    aligned = pd.concat([
+        strategy_daily_returns.rename('strategy'),
+        naive_returns.rename('naive')
+    ], axis=1).dropna()
+    beta = aligned['strategy'].cov(aligned['naive']) / aligned['naive'].var()
+    jensens_alpha = strategy_avg_excess - beta * naive_avg_excess
+    strategy_treynor = strategy_avg_excess / (beta if beta != 0 else 1)
+    strategy_beta = beta
 
     # Persist backtest results to the database (using dummy strategy and index IDs)
     # Ensure tables exist when running in a fresh or in-memory database


### PR DESCRIPTION
## Summary
- align strategy and benchmark returns before computing beta
- compute beta via covariance of aligned returns
- use updated beta for Jensen's alpha and Treynor ratio

## Testing
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685433bbf1748324a3178b71a89cf6e0