### PR TITLE
Add test fixtures for mocking yfinance and FRED

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,39 @@
+import pandas as pd
+import pytest
+
+@pytest.fixture
+def mock_yfinance(monkeypatch):
+    call_count = {'n': 0}
+
+    def dummy_download(ticker, start=None, end=None, group_by='column'):
+        call_count['n'] += 1
+        dates = pd.date_range(start=start, end=end, freq='D')
+        data = pd.DataFrame(
+            {
+                'Close': [100] * len(dates),
+                'Volume': [1000] * len(dates),
+            },
+            index=dates,
+        )
+        data.index.name = 'Date'
+        return data
+
+    monkeypatch.setattr('yfinance.download', dummy_download)
+    monkeypatch.setattr('utils.data_retrieval.yf.download', dummy_download)
+    monkeypatch.setattr('utils.backtesting.yf.download', dummy_download)
+    yield call_count
+
+
+@pytest.fixture
+def mock_fred(monkeypatch):
+    class DummyFred:
+        def __init__(self, api_key=None):
+            self.api_key = api_key
+
+        def get_series(self, series_id, observation_start=None, observation_end=None):
+            dates = pd.date_range(start=observation_start, end=observation_end, freq='D')
+            return pd.Series([1.0] * len(dates), index=dates)
+
+    monkeypatch.setattr('fredapi.Fred', DummyFred)
+    monkeypatch.setattr('utils.data_retrieval.Fred', DummyFred)
+    yield DummyFred

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -25,17 +25,7 @@ def test_home_route(create_client):
     assert response.status_code == 200
     assert b'Asset Allocation Backtester' in response.data  # Check for known content
 
-def test_backtest_route_simple(create_client, monkeypatch):
-    # Create a dummy version of get_yahoo_data to return a controlled DataFrame
-    import pandas as pd
-    def dummy_get_yahoo_data(symbol, start_date, end_date):
-        data = {
-            'Date': pd.date_range(start=start_date, periods=5, freq='D'),
-            'Close': [100, 102, 101, 103, 105]
-        }
-        return pd.DataFrame(data)
-    
-    monkeypatch.setattr('utils.data_retrieval.get_yahoo_data', dummy_get_yahoo_data)
+def test_backtest_route_simple(create_client, mock_yfinance, mock_fred):
     
     # Post form data to the /backtest route with the naive strategy.
     client = create_client()


### PR DESCRIPTION
## Summary
- add `tests/conftest.py` with fixtures to mock yfinance and FRED
- use fixtures in route and backtesting tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856744c60048324a8f71e3a63a8b1b5