### PR TITLE
Remove forced debug mode and document environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ In addition to return calculations, the backtester computes several risk-adjuste
    | `LOG_TO_STDOUT` | If set, logs are written to STDOUT instead of a file.          | not set                      |
    | `LOG_LEVEL`     | Logging verbosity level.                                       | `INFO`                       |
    | `FRED_API_KEY`  | API key for retrieving macro data from FRED (optional).        | not set                      |
+   | `FLASK_ENV`     | Flask environment (`development`, `production`, or `testing`). | `development`               |
 
    Example of exporting these variables in your shell:
 
@@ -205,15 +206,23 @@ In addition to return calculations, the backtester computes several risk-adjuste
    # Optional settings
    export DATABASE_URL="sqlite:///custom.db"
    export FRED_API_KEY="your_fred_api_key_here"
+   | `FLASK_ENV`     | Flask environment (`development`, `production`, or `testing`). | `development`               |
    ```
 
 ## Usage
 
 1. **Run the Application:**
 
-   Ensure the `SECRET_KEY` environment variable is defined, then start the Flask
-   server with your virtual environment activated:
-   
+   Ensure the `SECRET_KEY` environment variable is defined. Configure the
+   environment with `FLASK_ENV=development` for local debugging or
+   `FLASK_ENV=production` for deployment, then start the server:
+
+   ```bash
+   flask run
+   ```
+
+   You can also start it directly with Python:
+
    ```bash
    python app.py
    ```

--- a/app.py
+++ b/app.py
@@ -1,6 +1,6 @@
 from flask import Flask, render_template, request
 from extensions import db
-from config import DevelopmentConfig
+from config import DevelopmentConfig, TestingConfig, ProductionConfig
 import click
 import pandas as pd
 import numpy as np
@@ -10,7 +10,18 @@ from logging.handlers import RotatingFileHandler
 from utils.data_retrieval import get_risk_free_rate
 
 
-def create_app(config_class=DevelopmentConfig):
+def create_app(config_class=None):
+    """Create and configure the Flask application."""
+
+    if config_class is None:
+        env = os.getenv("FLASK_ENV", "development").lower()
+        if env == "production":
+            config_class = ProductionConfig
+        elif env == "testing":
+            config_class = TestingConfig
+        else:
+            config_class = DevelopmentConfig
+
     app = Flask(__name__)
     app.config.from_object(config_class)
     db.init_app(app)
@@ -278,4 +289,5 @@ def register_routes(app):
 app = create_app()
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    # Rely on the FLASK_ENV environment variable for debug configuration
+    app.run()


### PR DESCRIPTION
## Summary
- select the Flask configuration based on `FLASK_ENV`
- remove hard-coded `debug=True` when running the server
- document `FLASK_ENV` in README and update run instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68568af3c11c8324bdca05e8dd4a85a1