### PR TITLE
Handle zero variance in beta calculation

### DIFF
--- a/app.py
+++ b/app.py
@@ -228,7 +228,12 @@ def register_routes(app):
             strategy_daily_returns.rename('strategy'),
             naive_returns.rename('naive')
         ], axis=1).dropna()
-        beta = aligned['strategy'].cov(aligned['naive']) / aligned['naive'].var()
+        naive_var = aligned['naive'].var()
+        beta = (
+            aligned['strategy'].cov(aligned['naive']) / naive_var
+            if naive_var > 1e-8
+            else 0
+        )
         jensens_alpha = strategy_avg_excess - beta * naive_avg_excess
         strategy_treynor = strategy_avg_excess / (beta if beta != 0 else 1)
         strategy_beta = beta

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -38,3 +38,31 @@ def test_backtest_route_simple(create_client, mock_yfinance, mock_fred):
     # Check that the response is OK and contains expected elements.
     assert response.status_code == 200
     assert b'Cumulative Return' in response.data
+
+
+def test_beta_zero_flat_prices(create_client, mock_yfinance, mock_fred):
+    """Beta should be zero when benchmark returns have zero variance."""
+
+    client = create_client()
+    response = client.post(
+        '/backtest',
+        data={
+            'symbol': 'DUMMY',
+            'start_date': '2021-01-01',
+            'end_date': '2021-01-05',
+            'strategy_method': 'naive',
+        },
+    )
+
+    from bs4 import BeautifulSoup
+
+    soup = BeautifulSoup(response.data, 'html.parser')
+    beta_values = [
+        float(cells[1].text)
+        for row in soup.find_all('tr')
+        for cells in [row.find_all('td')]
+        if len(cells) == 2 and cells[0].text.strip() == 'Beta'
+    ]
+    assert len(beta_values) >= 2
+    # Second beta corresponds to the strategy metrics
+    assert beta_values[1] == 0.0


### PR DESCRIPTION
## Summary
- avoid divide-by-zero when computing beta in `app.py`
- verify beta calculation with a new regression test

## Testing
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856981d2c948324adcb063dcdbef1e8