### PR TITLE
Fix risk-free rate fill forward method

### DIFF
--- a/app.py
+++ b/app.py
@@ -201,7 +201,7 @@ def register_routes(app):
         prices_df.sort_values(by='Date', inplace=True)  # ensure sorted
         risk_free_df.sort_values(by='Date', inplace=True)  # ensure sorted
         merged_df = pd.merge_asof(prices_df, risk_free_df, on='Date', direction='backward')
-        merged_df['risk_free'] = merged_df['daily_rate'].fillna(method='ffill')
+        merged_df['risk_free'] = merged_df['daily_rate'].ffill()
 
         # Naive strategy metrics
         merged_df['naive_excess'] = naive_returns - merged_df['risk_free']  # excess returns

--- a/utils/data_retrieval.py
+++ b/utils/data_retrieval.py
@@ -73,7 +73,7 @@ def get_risk_free_rate(api_key: str, start_date: str, end_date: str) -> pd.DataF
     df = df.reindex(full_range)
     
     # Forward fill missing daily_rate values.
-    df['daily_rate'] = df['daily_rate'].fillna(method='ffill')
+    df['daily_rate'] = df['daily_rate'].ffill()
     df = df.reset_index().rename(columns={'index': 'Date'})
 
     return df[['Date', 'daily_rate']]


### PR DESCRIPTION
## Summary
- use `Series.ffill()` for merged risk-free rate
- use `Series.ffill()` for daily risk-free rate in data retrieval

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856986527d88324992e937ad912f2b1