### PR TITLE
Add SECRET_KEY validation

### DIFF
--- a/app.py
+++ b/app.py
@@ -24,6 +24,7 @@ def create_app(config_class=None):
 
     app = Flask(__name__)
     app.config.from_object(config_class)
+    config_class.validate()
     db.init_app(app)
 
     # --- Logging Setup ---

--- a/config.py
+++ b/config.py
@@ -26,6 +26,14 @@ class Config:
     # FRED API Key (optional, can be set in environment)
     FRED_API_KEY = os.environ.get('FRED_API_KEY')
 
+    @classmethod
+    def validate(cls):
+        """Ensure a SECRET_KEY is provided for non-testing configs."""
+        if not cls.TESTING and not cls.SECRET_KEY:
+            raise RuntimeError(
+                "SECRET_KEY environment variable must be set for production and development"
+            )
+
 class DevelopmentConfig(Config):
     DEBUG = True
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,9 @@
+import os
 import pandas as pd
 import pytest
+
+# Ensure SECRET_KEY is set for tests that import the app module
+os.environ.setdefault("SECRET_KEY", "test-secret-key")
 
 @pytest.fixture
 def mock_yfinance(monkeypatch):


### PR DESCRIPTION
## Summary
- enforce `SECRET_KEY` presence for development and production
- ensure tests set a default `SECRET_KEY`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856987a20c48324bd59e004b922468c