### PR TITLE
Add date validation for backtesting form

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist/
 # IDE and Editor files
 .vscode/
 .idea/
+final_project.db

--- a/app.py
+++ b/app.py
@@ -8,6 +8,7 @@ import os
 import logging
 from logging.handlers import RotatingFileHandler
 from utils.data_retrieval import get_risk_free_rate
+from utils.validation import validate_date_range
 
 
 def create_app(config_class=None):
@@ -99,6 +100,10 @@ def register_routes(app):
         symbol = request.form.get('symbol')
         start_date = request.form.get('start_date')
         end_date = request.form.get('end_date')
+        try:
+            validate_date_range(start_date, end_date)
+        except ValueError as exc:
+            return str(exc), 400
         # Read the strategy selection; valid options: 'naive', 'advanced', 'macro', 'macro_only'
         strategy_method = request.form.get('strategy_method', 'naive')
 

--- a/utils/validation.py
+++ b/utils/validation.py
@@ -1,0 +1,19 @@
+"""Validation helpers for form input."""
+
+from datetime import datetime
+
+
+def validate_date_range(start_date: str, end_date: str, max_days: int = 3650) -> None:
+    """Validate that dates are in YYYY-MM-DD format and within a reasonable range."""
+    try:
+        start = datetime.strptime(start_date, "%Y-%m-%d")
+        end = datetime.strptime(end_date, "%Y-%m-%d")
+    except ValueError as exc:
+        raise ValueError("Dates must be in YYYY-MM-DD format") from exc
+
+    if start >= end:
+        raise ValueError("start_date must be earlier than end_date")
+
+    if (end - start).days > max_days:
+        raise ValueError(f"Date range cannot exceed {max_days} days")
+


### PR DESCRIPTION
## Summary
- add reusable `validate_date_range` helper
- integrate validation into `/backtest` route
- ignore generated SQLite database file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685698d4ed9483249c197d87b74c237f