### PR TITLE
Improve ETF volume caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,10 @@ This project is a web application for backtesting asset allocation strategies us
   Backtest results are stored in a SQLite database using SQLAlchemy.
 
 - **ETF Volume Caching:**
-  Volume data retrieved from yfinance is cached in memory per symbol so repeated
-  strategy calls avoid unnecessary network requests.
+  Volume data retrieved from yfinance is cached with an in-memory LRU cache.
+  Entries beyond the size limit are optionally written to disk so repeated
+  strategy calls avoid unnecessary network requests without unbounded memory
+  usage.
 
 - **Testing:**  
   Includes unit and integration tests (using pytest) to ensure code quality and robustness.


### PR DESCRIPTION
## Summary
- limit ETF volume cache size with an in-memory LRU
- optionally save evicted cache entries to disk
- document new behavior in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68569b68d70083249ee217dd7d0bd7da