### PR TITLE
Fix undefined variable in backtest view

### DIFF
--- a/app.py
+++ b/app.py
@@ -223,6 +223,10 @@ def register_routes(app):
         strategy_sortino = metrics["strategy_sortino"]
         strategy_beta = metrics["strategy_beta"]
         jensens_alpha = metrics["strategy_jensens_alpha"]
+        # Jensen's alpha for the benchmark is always zero
+        naive_alpha = 0.0
+        # Use Jensen's alpha as the strategy alpha metric
+        strategy_alpha = jensens_alpha
         strategy_treynor = metrics["strategy_treynor"]
         strategy_drawdown = metrics["strategy_drawdown"]
 


### PR DESCRIPTION
## Summary
- fix undefined `naive_alpha` in backtest route
- map Jensen's alpha from metrics to `strategy_alpha`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859bc87a1988324bf14d467d182b8b2