### PR TITLE
Fix missing import in backtesting utilities

### DIFF
--- a/utils/backtesting.py
+++ b/utils/backtesting.py
@@ -8,6 +8,7 @@ import math
 import pandas as pd
 import numpy as np
 import yfinance as yf  # For ETF liquidity data fetching
+from utils.data_retrieval import get_risk_free_rate
 
 # In-memory LRU cache for ETF volume data keyed by (ticker, start_date, end_date)
 _ETF_VOLUME_CACHE_MAX_SIZE = 10


### PR DESCRIPTION
## Summary
- import `get_risk_free_rate` in `utils/backtesting.py`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685c504dfd648324b9661d4cfec5e2d8