### PR TITLE
Fix Sortino ratio when no negative returns

### DIFF
--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -47,3 +47,26 @@ def test_compute_metrics_zero_variance():
     )
 
     assert metrics["strategy_beta"] == 0
+
+def test_sortino_no_negative_returns():
+    dates = pd.date_range(start="2021-01-01", periods=5, freq="D")
+    returns = pd.Series([0.01, 0.02, 0.03, 0.01, 0.02])
+    prices_df = pd.DataFrame({"Date": dates, "returns": returns})
+    naive_returns = prices_df["returns"]
+    strategy_daily_returns = naive_returns.copy()
+    naive_series = (naive_returns + 1).cumprod()
+    strategy_series = naive_series.copy()
+
+    metrics = compute_metrics(
+        prices_df,
+        naive_returns,
+        strategy_daily_returns,
+        naive_series,
+        strategy_series,
+        "2021-01-01",
+        "2021-01-05",
+    )
+
+    assert not np.isnan(metrics["naive_sortino"])
+    assert not np.isnan(metrics["strategy_sortino"])
+

--- a/utils/backtesting.py
+++ b/utils/backtesting.py
@@ -294,7 +294,10 @@ def compute_metrics(
     naive_downside = (
         np.std(merged_df["naive_excess"][merged_df["naive_excess"] < 0]) * np.sqrt(252)
     )
-    naive_sortino = naive_avg_excess / (naive_downside if naive_downside != 0 else 1)
+    if np.isnan(naive_downside) or naive_downside == 0:
+        naive_sortino = naive_avg_excess
+    else:
+        naive_sortino = naive_avg_excess / naive_downside
     naive_drawdown = (naive_series / naive_series.cummax() - 1).min()
 
     # --- Active strategy metrics ---
@@ -307,9 +310,10 @@ def compute_metrics(
     strategy_downside = (
         np.std(merged_df["strategy_excess"][merged_df["strategy_excess"] < 0]) * np.sqrt(252)
     )
-    strategy_sortino = strategy_avg_excess / (
-        strategy_downside if strategy_downside != 0 else 1
-    )
+    if np.isnan(strategy_downside) or strategy_downside == 0:
+        strategy_sortino = strategy_avg_excess
+    else:
+        strategy_sortino = strategy_avg_excess / strategy_downside
     strategy_drawdown = (strategy_series / strategy_series.cummax() - 1).min()
 
     aligned = pd.concat(


### PR DESCRIPTION
## Summary
- handle NaN downside deviation in `compute_metrics`
- test Sortino ratio is finite when there are no negative returns

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c504dfd648324b9661d4cfec5e2d8