### PR TITLE
Fix macro z-score calculation

### DIFF
--- a/tests/test_backtesting.py
+++ b/tests/test_backtesting.py
@@ -9,6 +9,7 @@ from utils.backtesting import (
     full_invested_strategy,
     dynamic_market_timing_strategy_macro,
     dynamic_market_timing_strategy_advanced,
+    dynamic_macro_strategy,
     _etf_volume_cache,
     _enforce_cache_limit,
     _ETF_VOLUME_CACHE_MAX_SIZE,
@@ -133,3 +134,16 @@ def test_momentum_signal_no_overflow():
     down["returns"] = down["Close"].pct_change().fillna(0)
     alloc_down = dynamic_market_timing_strategy_advanced(down)
     assert np.isfinite(alloc_down.iloc[-1])
+
+
+def test_macro_allocation_positive_trend():
+    """Macro-only strategy should allocate positively when macro trend is up."""
+    dates = pd.date_range(start="2021-01-01", periods=40, freq="D")
+    prices = pd.DataFrame({"Date": dates, "Close": np.linspace(100, 140, 40)})
+    macro = pd.DataFrame({"date": dates, "value": np.linspace(1, 2, 40)})
+
+    alloc = dynamic_macro_strategy(prices, macro)
+
+    # After the lookback period, the allocation should be positive for an
+    # upward-trending macro series.
+    assert alloc.iloc[-1] > 0

--- a/utils/backtesting.py
+++ b/utils/backtesting.py
@@ -365,7 +365,7 @@ def dynamic_market_timing_strategy_macro(df, macro_df, etf_ticker=None):
     macro_series.index = df.index
     rolling_avg = macro_series.rolling(lookback).mean()
     rolling_std = macro_series.rolling(lookback).std().replace(0, 1)
-    macro_z = (rolling_avg - macro_series) / rolling_std
+    macro_z = (macro_series - rolling_avg) / rolling_std
     macro_signal = np.tanh(macro_z).fillna(0)
 
     combined_signal = 0.5 * momentum_signal + 0.5 * macro_signal
@@ -444,7 +444,7 @@ def dynamic_macro_strategy(
                 macro_window = macro_df[macro_df['date'] <= current_date].tail(lookback)
                 rolling_avg = macro_window['value'].mean()
                 rolling_std = macro_window['value'].std()
-                macro_z = (rolling_avg - current_macro) / (rolling_std if rolling_std != 0 else 1)
+                macro_z = (current_macro - rolling_avg) / (rolling_std if rolling_std != 0 else 1)
                 allocation = math.tanh(macro_z)
                 allocation = max(-1, min(allocation, 1))
             allocations.append(allocation)


### PR DESCRIPTION
## Summary
- correct macro signal orientation in backtesting utilities
- verify macro-only strategy gives positive allocation when macro trend is upward

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c504dfd648324b9661d4cfec5e2d8