### PR TITLE
Fix volatility scaling divide-by-zero

### DIFF
--- a/tests/test_backtesting.py
+++ b/tests/test_backtesting.py
@@ -147,3 +147,16 @@ def test_macro_allocation_positive_trend():
     # After the lookback period, the allocation should be positive for an
     # upward-trending macro series.
     assert alloc.iloc[-1] > 0
+
+
+def test_zero_volatility_allocation():
+    """Strategy should not raise errors when volatility is zero."""
+    dates = pd.date_range(start="2021-01-01", periods=30, freq="D")
+    df = pd.DataFrame({"Date": dates, "Close": 100, "Volume": 1000})
+    df["returns"] = df["Close"].pct_change().fillna(0)
+
+    alloc = dynamic_market_timing_strategy_advanced(df)
+
+    assert np.all(np.isfinite(alloc))
+    # After the lookback period the allocation should equal the momentum signal
+    assert alloc.iloc[20] == pytest.approx(0.5, abs=1e-6)

--- a/utils/backtesting.py
+++ b/utils/backtesting.py
@@ -211,7 +211,11 @@ def dynamic_market_timing_strategy_advanced(
     # Volatility scaling
     vol = df["returns"].rolling(lookback).std()
     target_vol = 0.02
-    volatility_signal = np.where(vol > target_vol, target_vol / vol, 1.0)
+    # Avoid divide-by-zero warnings by applying the ratio only where vol is
+    # greater than the target. Remaining values stay at ``1``.
+    volatility_signal = np.ones_like(vol, dtype=float)
+    mask = vol > target_vol
+    volatility_signal[mask] = target_vol / vol[mask]
     volatility_signal = np.minimum(volatility_signal, 1)
 
     # ---------------------------------------------------------------
@@ -401,7 +405,9 @@ def dynamic_market_timing_strategy_macro(df, macro_df, etf_ticker=None):
     # Volatility scaling
     vol = df["returns"].rolling(lookback).std()
     target_vol = 0.02
-    vol_scaling = np.where(vol > target_vol, target_vol / vol, 1.0)
+    vol_scaling = np.ones_like(vol, dtype=float)
+    mask = vol > target_vol
+    vol_scaling[mask] = target_vol / vol[mask]
 
     # ---------------------------------------------------------------
     # Liquidity signal


### PR DESCRIPTION
## Summary
- avoid division by zero when calculating volatility-based scaling
- add regression test for zero-volatility data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d8f0be1bc83248e70dd77aed931d9