### PR TITLE
Fix divide-by-zero warning in volatility scaling

### DIFF
--- a/utils/backtesting.py
+++ b/utils/backtesting.py
@@ -211,7 +211,9 @@ def dynamic_market_timing_strategy_advanced(
     # Volatility scaling
     vol = df["returns"].rolling(lookback).std()
     target_vol = 0.02
-    volatility_signal = np.where(vol > target_vol, target_vol / vol, 1.0)
+    volatility_signal = pd.Series(1.0, index=df.index)
+    mask = vol > target_vol
+    volatility_signal[mask] = target_vol / vol[mask]
     volatility_signal = np.minimum(volatility_signal, 1)
 
     # ---------------------------------------------------------------
@@ -401,7 +403,9 @@ def dynamic_market_timing_strategy_macro(df, macro_df, etf_ticker=None):
     # Volatility scaling
     vol = df["returns"].rolling(lookback).std()
     target_vol = 0.02
-    vol_scaling = np.where(vol > target_vol, target_vol / vol, 1.0)
+    vol_scaling = pd.Series(1.0, index=df.index)
+    mask = vol > target_vol
+    vol_scaling[mask] = target_vol / vol[mask]
 
     # ---------------------------------------------------------------
     # Liquidity signal


### PR DESCRIPTION
## Summary
- avoid numpy divide by zero in volatility scaling logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d8f0be1bc83248e70dd77aed931d9