### PR TITLE
Add static risk-free rate configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ In addition to return calculations, the backtester computes several risk-adjuste
    | `LOG_TO_STDOUT` | If set, logs are written to STDOUT instead of a file.          | not set                      |
    | `LOG_LEVEL`     | Logging verbosity level.                                       | `INFO`                       |
    | `FRED_API_KEY`  | API key for retrieving macro data from FRED (optional).        | not set                      |
+   | `RISK_FREE_RATE`| Daily risk-free rate used when `FRED_API_KEY` is unset.        | not set                      |
    | `FLASK_ENV`     | Selects the configuration: use `development` for local debugging (default), `production` for deployment, or `testing` during tests. | `development`               |
 
    Example of exporting these variables in your shell:
@@ -208,7 +209,13 @@ In addition to return calculations, the backtester computes several risk-adjuste
    # Optional settings
    export DATABASE_URL="sqlite:///custom.db"
    export FRED_API_KEY="your_fred_api_key_here"
+   # Optional fallback if FRED_API_KEY is not provided
+   export RISK_FREE_RATE="0.0001"
    ```
+
+   The backtesting metrics need a risk-free rate. Provide `FRED_API_KEY` to
+   download the 3‑month Treasury yield or define `RISK_FREE_RATE` with a static
+   daily rate. If neither is set, metric computation will fail.
 
 ## Usage
 

--- a/app.py
+++ b/app.py
@@ -202,6 +202,10 @@ def register_routes(app):
             strategy_daily_returns = naive_returns
             strategy_alpha = 0.0
 
+        fred_api_key = os.getenv("FRED_API_KEY")
+        risk_free_env = os.getenv("RISK_FREE_RATE")
+        risk_free_rate = float(risk_free_env) if risk_free_env is not None else None
+
         metrics = compute_metrics(
             prices_df,
             naive_returns,
@@ -210,7 +214,8 @@ def register_routes(app):
             strategy_series,
             start_date,
             end_date,
-            os.getenv("FRED_API_KEY"),
+            fred_api_key,
+            risk_free_rate=risk_free_rate,
         )
         naive_vol_excess = metrics["naive_vol_excess"]
         naive_avg_excess = metrics["naive_avg_excess"]

--- a/config.py
+++ b/config.py
@@ -25,6 +25,12 @@ class Config:
     
     # FRED API Key (optional, can be set in environment)
     FRED_API_KEY = os.environ.get('FRED_API_KEY')
+    # Static daily risk-free rate (optional, used if FRED_API_KEY is not set)
+    RISK_FREE_RATE = (
+        float(os.environ.get('RISK_FREE_RATE'))
+        if os.environ.get('RISK_FREE_RATE') is not None
+        else None
+    )
 
     @classmethod
     def validate(cls):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import pytest
 
 # Ensure SECRET_KEY is set for tests that import the app module
 os.environ.setdefault("SECRET_KEY", "test-secret-key")
+os.environ.setdefault("RISK_FREE_RATE", "0")
 
 @pytest.fixture
 def mock_yfinance(monkeypatch):

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -20,6 +20,7 @@ def test_compute_metrics_basic():
         strategy_series,
         "2021-01-01",
         "2021-01-05",
+        risk_free_rate=0,
     )
 
     assert np.isclose(metrics["strategy_beta"], 2.0)
@@ -44,6 +45,7 @@ def test_compute_metrics_zero_variance():
         strategy_series,
         "2021-01-01",
         "2021-01-05",
+        risk_free_rate=0,
     )
 
     assert metrics["strategy_beta"] == 0
@@ -65,6 +67,7 @@ def test_sortino_no_negative_returns():
         strategy_series,
         "2021-01-01",
         "2021-01-05",
+        risk_free_rate=0,
     )
 
     assert not np.isnan(metrics["naive_sortino"])
@@ -90,6 +93,7 @@ def test_compute_metrics_handles_unsorted_data():
         strategy_series,
         "2021-01-01",
         "2021-01-05",
+        risk_free_rate=0,
     )
 
     assert np.isclose(metrics["strategy_beta"], 2.0)

--- a/utils/backtesting.py
+++ b/utils/backtesting.py
@@ -262,6 +262,7 @@ def compute_metrics(
     start_date: str,
     end_date: str,
     fred_api_key: Optional[str] = None,
+    risk_free_rate: Optional[float] = None,
 ) -> dict:
     """Calculate performance metrics for naive and active strategies.
 
@@ -282,7 +283,10 @@ def compute_metrics(
         Date range used to fetch the risk‑free rate if ``fred_api_key`` is
         provided.
     fred_api_key : str, optional
-        API key for FRED. If not supplied, a zero risk‑free rate is assumed.
+        API key for FRED used to download the 3‑month Treasury yield from FRED.
+    risk_free_rate : float, optional
+        Daily risk‑free rate to use when ``fred_api_key`` is not supplied.
+        One of ``fred_api_key`` or ``risk_free_rate`` must be provided.
 
     Returns
     -------
@@ -293,8 +297,12 @@ def compute_metrics(
     if fred_api_key:
         risk_free_df = get_risk_free_rate(fred_api_key, start_date, end_date)
     else:
+        if risk_free_rate is None:
+            raise ValueError(
+                "Either fred_api_key or risk_free_rate must be provided"
+            )
         date_range = pd.date_range(start=start_date, end=end_date, freq="D")
-        risk_free_df = pd.DataFrame({"Date": date_range, "daily_rate": 0})
+        risk_free_df = pd.DataFrame({"Date": date_range, "daily_rate": risk_free_rate})
 
     prices_df = prices_df.copy()
     prices_df.sort_values(by="Date", inplace=True)


### PR DESCRIPTION
## Summary
- allow passing a static risk-free rate to `compute_metrics`
- read `RISK_FREE_RATE` in the Flask app for metrics
- expose the new config in `Config`
- document the environment variable in the README
- update tests to provide the fallback rate

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ea48753348324a94229214a714946