### PR TITLE
Address DataFrame logging risk

### DIFF
--- a/app.py
+++ b/app.py
@@ -118,7 +118,12 @@ def register_routes(app):
         def flatten_col(col):
             return col[1] if isinstance(col, tuple) and len(col) > 1 else col
         prices_df.columns = [flatten_col(col) for col in prices_df.columns]
-        app.logger.info("Flattened Price DataFrame columns: " + str(prices_df.columns.tolist()))
+        cols_list = prices_df.columns.tolist()
+        if len(cols_list) > 5:
+            display_cols = cols_list[:5] + ["..."]
+        else:
+            display_cols = cols_list
+        app.logger.info("Flattened DataFrame columns (truncated): %s", display_cols)
     
         # If columns appear as ['', '^STOXX50E', '^STOXX50E', '^STOXX50E', '^STOXX50E', '^STOXX50E', '^STOXX50E'], rename manually:
         cols = prices_df.columns.tolist()


### PR DESCRIPTION
## Summary
- truncate DataFrame column logging to avoid dumping entire lists

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ea4ce4c24832486dd49d370f98c5b