### PR TITLE
Use beta when computing Treynor ratio

### DIFF
--- a/app.py
+++ b/app.py
@@ -223,6 +223,8 @@ def register_routes(app):
         strategy_sortino = metrics["strategy_sortino"]
         strategy_beta = metrics["strategy_beta"]
         jensens_alpha = metrics["strategy_jensens_alpha"]
+        naive_beta = metrics["naive_beta"]
+        naive_treynor = metrics["naive_treynor"]
         # Jensen's alpha for the benchmark is always zero
         naive_alpha = 0.0
         # Use Jensen's alpha as the strategy alpha metric
@@ -279,8 +281,8 @@ def register_routes(app):
             plot_html=plot_html,
             naive_sharpe=naive_sharpe,
             naive_sortino=naive_sortino,
-            naive_beta=1,
-            naive_treynor=naive_avg_excess,
+            naive_beta=naive_beta,
+            naive_treynor=naive_treynor,
             naive_vol_excess=naive_vol_excess,
             naive_drawdown=naive_drawdown,
             strategy_sharpe=strategy_sharpe,

--- a/utils/backtesting.py
+++ b/utils/backtesting.py
@@ -346,6 +346,8 @@ def compute_metrics(
     beta = aligned["strategy"].cov(aligned["naive"]) / naive_var if naive_var > 1e-8 else 0
     jensens_alpha = strategy_avg_excess - beta * naive_avg_excess
     strategy_treynor = strategy_avg_excess / (beta if beta != 0 else 1)
+    naive_beta = 1.0 if naive_var > 1e-8 else 0
+    naive_treynor = naive_avg_excess / (naive_beta if naive_beta != 0 else 1)
 
     return {
         "naive_sharpe": naive_sharpe,
@@ -353,6 +355,8 @@ def compute_metrics(
         "naive_vol_excess": naive_vol_excess,
         "naive_drawdown": naive_drawdown,
         "naive_avg_excess": naive_avg_excess,
+        "naive_beta": naive_beta,
+        "naive_treynor": naive_treynor,
         "strategy_sharpe": strategy_sharpe,
         "strategy_sortino": strategy_sortino,
         "strategy_beta": beta,


### PR DESCRIPTION
## Summary
- compute beta for the naive portfolio and derive Treynor using it
- expose `naive_beta` and `naive_treynor` to the results template

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ea50ed3548324965957d2c9dc0718