### PR TITLE
Enable CSRF protection

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,5 +1,5 @@
 from flask import Flask, render_template, request
-from extensions import db
+from extensions import db, csrf
 from config import DevelopmentConfig, TestingConfig, ProductionConfig
 import click
 import pandas as pd
@@ -27,6 +27,7 @@ def create_app(config_class=None):
     app.config.from_object(config_class)
     config_class.validate()
     db.init_app(app)
+    csrf.init_app(app)
 
     # --- Logging Setup ---
     if not app.debug and not app.config['LOG_TO_STDOUT']:

--- a/config.py
+++ b/config.py
@@ -41,6 +41,7 @@ class TestingConfig(Config):
     TESTING = True
     SECRET_KEY = os.environ.get('SECRET_KEY') or 'test-secret-key'
     SQLALCHEMY_DATABASE_URI = 'sqlite:///:memory:'
+    WTF_CSRF_ENABLED = False
 
 class ProductionConfig(Config):
     DEBUG = False

--- a/extensions.py
+++ b/extensions.py
@@ -1,3 +1,5 @@
 from flask_sqlalchemy import SQLAlchemy
+from flask_wtf import CSRFProtect
 
 db = SQLAlchemy()
+csrf = CSRFProtect()

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ charset-normalizer==3.4.2
 click==8.1.8
 Flask==3.1.1
 Flask-SQLAlchemy==3.1.1
+Flask-WTF==1.2.2
 fredapi==0.5.2
 frozendict==2.4.6
 greenlet==3.2.3

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,6 +10,7 @@
   <div class="container mt-5">
     <h1>Asset Allocation Backtester</h1>
     <form action="/backtest" method="post" class="mb-4">
+      {{ csrf_token() }}
       <div class="mb-3">
         <label for="symbol" class="form-label">Select Index:</label>
         <select class="form-select" id="symbol" name="symbol" required>


### PR DESCRIPTION
## Summary
- add Flask-WTF dependency
- initialize CSRFProtect extension
- disable CSRF in tests
- include CSRF token in the main form

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ea51fe0288324a0397374f2eb42c6