### PR TITLE
Add coverage badge generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
+
+      - name: Black style check
+        run: black --check .
+
+      - name: Ruff lint
+        run: ruff .
+
+      - name: Mypy type check
+        run: mypy .
+
+      - name: Run tests with coverage
+        run: |
+          pytest --cov=./ --cov-report=xml
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage.xml
+
+      - name: Generate coverage badge
+        uses: tj-actions/coverage-badge@v2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # CS50 Final Project: Asset Allocation Backtester
+![coverage](coverage.svg)
 
 #### Description:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,11 @@
+[tool.black]
+line-length = 100
+target-version = ["py311"]
+
+[tool.ruff]
+line-length = 100
+
+[tool.mypy]
+python_version = "3.11"
+ignore_missing_imports = true
+

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,6 @@
+black
+ruff
+mypy
+pytest
+pytest-cov
+coverage


### PR DESCRIPTION
## Summary
- update the CI workflow to store coverage results as an artifact
- generate a coverage badge using tj-actions/coverage-badge
- show coverage badge in the README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685e9e59416c832489b38c9788c08df2