### PR TITLE
Fix CI failure by updating coverage badge action and linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Generate coverage badge
         if: github.event_name == 'push'
-        uses: tj-actions/coverage-badge@v2
+        uses: tj-actions/coverage-badge@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/app.py
+++ b/app.py
@@ -6,7 +6,6 @@ import pandas as pd
 import os
 import logging
 from logging.handlers import RotatingFileHandler
-from typing import Optional
 
 from utils.validation import validate_date_range
 
@@ -57,9 +56,7 @@ def _load_cache(prefix: str, symbol: str, start: str, end: str) -> pd.DataFrame 
     return None
 
 
-def _save_cache(
-    df: pd.DataFrame, prefix: str, symbol: str, start: str, end: str
-) -> None:
+def _save_cache(df: pd.DataFrame, prefix: str, symbol: str, start: str, end: str) -> None:
     """Persist a DataFrame to disk for later reuse.
 
     Parameters

--- a/tests/test_backtesting.py
+++ b/tests/test_backtesting.py
@@ -74,9 +74,7 @@ def test_simple_backtest_execution_model():
 
     model = ExecutionModel(bid_ask_spread=0.01, commission=0.0)
 
-    cumulative_return, alpha, series = simple_backtest(
-        df.copy(), strategy, execution_model=model
-    )
+    cumulative_return, alpha, series = simple_backtest(df.copy(), strategy, execution_model=model)
 
     df["returns"] = df["Close"].pct_change().fillna(0)
     alloc = strategy(df)


### PR DESCRIPTION
## Summary
- update coverage badge action to v3
- drop unused Optional import
- format code with black

## Testing
- `ruff check .`
- `black --check app.py tests/test_backtesting.py`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6864d65ad19083249819880b670f789d