### PR TITLE
Fix ETF mapping for European indices

### DIFF
--- a/app.py
+++ b/app.py
@@ -156,8 +156,8 @@ def register_routes(app: Flask) -> None:
         "^FTSE": "ISF",
         "^N225": "EWJ",
         "^HSI": "2800.HK",
-        "^GDAXI": "DAXY",
-        "^FCHI": "EWU",
+        "^GDAXI": "EWG",
+        "^FCHI": "EWQ",
         "^STOXX50E": "FEZ",
         "^BSESN": "INDA",
     }


### PR DESCRIPTION
## Summary
- correct ETF tickers for CAC 40 and DAX indices

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866c58676f48324bbae87e16d48aec1