### PR TITLE
Fix CI coverage badge action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Generate coverage badge
         if: github.event_name == 'push'
-        uses: tj-actions/coverage-badge@v3
+        uses: tj-actions/coverage-badge-py@v2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary
- update CI workflow to use `coverage-badge-py@v2`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866c95f2e84832494189af41ad3d332