### PR TITLE
Sanitize cache filenames

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,7 +7,7 @@ import os
 import logging
 from logging.handlers import RotatingFileHandler
 
-from utils.validation import validate_date_range
+from utils.validation import validate_date_range, sanitize_symbol
 
 CACHE_DIR = os.path.join(os.path.dirname(__file__), "cache")
 
@@ -29,7 +29,8 @@ def _cache_path(prefix: str, symbol: str, start: str, end: str) -> str:
     str
         Absolute path to the cache file on disk.
     """
-    filename = f"{prefix}_{symbol}_{start}_{end}.pkl"
+    safe_symbol = sanitize_symbol(symbol)
+    filename = f"{prefix}_{safe_symbol}_{start}_{end}.pkl"
     return os.path.join(CACHE_DIR, filename)
 
 

--- a/tests/test_cache_security.py
+++ b/tests/test_cache_security.py
@@ -1,0 +1,12 @@
+import os
+from app import _cache_path
+
+
+def test_cache_path_sanitizes(tmp_path):
+    path = _cache_path('yahoo', '../evil', '2021-01-01', '2021-01-02')
+    # Path should be within cache directory
+    assert os.path.dirname(path).endswith('cache')
+    filename = os.path.basename(path)
+    assert '..' not in filename
+    assert '/' not in filename and '\\' not in filename
+

--- a/utils/validation.py
+++ b/utils/validation.py
@@ -1,6 +1,10 @@
 """Validation helpers for form input."""
 
 from datetime import datetime
+import os
+import re
+
+_SYMBOL_SAFE_CHARS = re.compile(r"[^A-Za-z0-9.^_-]")
 
 
 def validate_date_range(start_date: str, end_date: str, max_days: int = 3650) -> None:
@@ -29,3 +33,18 @@ def validate_date_range(start_date: str, end_date: str, max_days: int = 3650) ->
 
     if (end - start).days > max_days:
         raise ValueError(f"Date range cannot exceed {max_days} days")
+
+
+def sanitize_symbol(symbol: str) -> str:
+    """Return a filesystem-safe representation of ``symbol``.
+
+    Any path separators are replaced and unsafe characters are converted to
+    underscores to prevent path traversal or file overwrites.
+    """
+
+    sanitized = symbol.replace(os.path.sep, "_")
+    if os.path.altsep:
+        sanitized = sanitized.replace(os.path.altsep, "_")
+    sanitized = sanitized.replace("..", "")
+    sanitized = _SYMBOL_SAFE_CHARS.sub("_", sanitized)
+    return sanitized


### PR DESCRIPTION
## Summary
- sanitize ticker symbols for cache path
- add tests covering sanitization logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869140b594c832493eaa6a2624d0fb6