### PR TITLE
Drop unused parameter from dynamic_macro_strategy

### DIFF
--- a/app.py
+++ b/app.py
@@ -317,7 +317,7 @@ def register_routes(app: Flask) -> None:
                         502,
                     )
                 macro_df = cached
-            allocation = dynamic_macro_strategy(prices_df, macro_df, etf_ticker)
+            allocation = dynamic_macro_strategy(prices_df, macro_df)
             prices_df["returns"] = prices_df[price_col].pct_change().fillna(0)
             strategy_series = (prices_df["returns"] * allocation + 1).cumprod()
             strategy_return = float(strategy_series.iloc[-1] - 1)

--- a/utils/backtesting.py
+++ b/utils/backtesting.py
@@ -487,11 +487,7 @@ def dynamic_market_timing_strategy_macro(df, macro_df, etf_ticker=None):
     return allocation
 
 
-def dynamic_macro_strategy(
-    df: pd.DataFrame,
-    macro_df: pd.DataFrame,
-    etf_ticker: Optional[str] = None,
-) -> pd.Series:
+def dynamic_macro_strategy(df: pd.DataFrame, macro_df: pd.DataFrame) -> pd.Series:
     """Allocate purely based on macroeconomic signals.
 
     Parameters
@@ -500,8 +496,6 @@ def dynamic_macro_strategy(
         Price data with a ``Date`` column.
     macro_df : pd.DataFrame
         Macroeconomic values with ``date`` and ``value`` columns.
-    etf_ticker : str, optional
-        Kept for API compatibility; ignored in this implementation.
 
     Returns
     -------


### PR DESCRIPTION
## Summary
- remove `etf_ticker` argument from `dynamic_macro_strategy`
- update call site in `app.py`

## Testing
- `python3 -m pytest -q`
- `black --check .`
- `ruff check .`
- `mypy .`


------
https://chatgpt.com/codex/tasks/task_e_6869144ec57083248ba3a1b7945ef938