### PR TITLE
Fix alpha calculation

### DIFF
--- a/tests/test_backtesting.py
+++ b/tests/test_backtesting.py
@@ -37,6 +37,24 @@ def test_simple_backtest():
 
     # Test to compare the values (allowing small differences)
     np.testing.assert_almost_equal(cumulative_return, expected_cum_return, decimal=2)
+    assert alpha == pytest.approx(0, abs=1e-8)
+
+
+def test_simple_backtest_leveraged_alpha():
+    """Alpha should be ~0 for a leveraged strategy with no costs."""
+    data = {
+        "Date": pd.date_range(start="2021-01-01", periods=5, freq="D"),
+        "Close": [100, 102, 101, 103, 105],
+    }
+    df = pd.DataFrame(data)
+
+    cumulative_return, alpha, _ = simple_backtest(df.copy(), lambda _df: 2.0)
+
+    expected_returns = df["Close"].pct_change().fillna(0)
+    expected_cum_return = (expected_returns * 2 + 1).cumprod().iloc[-1] - 1
+
+    np.testing.assert_allclose(cumulative_return, expected_cum_return)
+    assert alpha == pytest.approx(0, abs=1e-8)
 
 
 def test_simple_backtest_with_execution_costs():

--- a/utils/backtesting.py
+++ b/utils/backtesting.py
@@ -193,7 +193,21 @@ def simple_backtest(
         raise ValueError("Cumulative series is empty. Check your data and date range.")
 
     cumulative_return = cumulative_series.iloc[-1] - 1
-    alpha = cumulative_return - prices_df["returns"].mean()
+
+    aligned = pd.concat(
+        [
+            prices_df["strategy_returns"].rename("strategy"),
+            prices_df["returns"].rename("benchmark"),
+        ],
+        axis=1,
+    ).dropna()
+
+    bench_var = aligned["benchmark"].var()
+    beta = aligned["strategy"].cov(aligned["benchmark"]) / bench_var if bench_var > 1e-8 else 0
+
+    strategy_mean = aligned["strategy"].mean()
+    bench_mean = aligned["benchmark"].mean()
+    alpha = strategy_mean - beta * bench_mean
 
     return cumulative_return, alpha, cumulative_series
 


### PR DESCRIPTION
## Summary
- compute Jensen's alpha in `simple_backtest`
- check alpha in tests and validate leveraged case

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869143abb3c83249695cf99ebb7be10